### PR TITLE
Correction for `persistentvolumeclaims` limit

### DIFF
--- a/4 Understand and Define Resource Requirements Limits and Quotas/README.md
+++ b/4 Understand and Define Resource Requirements Limits and Quotas/README.md
@@ -51,7 +51,7 @@ Attempt to deploy the pod defined in `lightweight-svc.yaml`. Troubleshoot the po
 
 ### Task 3
 
-Create a namespace, `ps-test`, that limits the total amount of storage that can be requested to 100Gi. Ensure that no single PersistentVolumeClaim can request more than 10Gi.
+Create a namespace, `ps-test`, that limits the total amount of storage that can be requested to 100Gi. Ensure that no more than 10 PersistentVolumeClaims can be requested.
 
 ## Clean Up
 

--- a/4 Understand and Define Resource Requirements Limits and Quotas/answers.md
+++ b/4 Understand and Define Resource Requirements Limits and Quotas/answers.md
@@ -69,7 +69,7 @@ kubectl apply -f lightweight-svc.yaml
 
 ## Task 3
 
-Create a namespace, `ps-test`, that limits the total amount of storage that can be requested to 100Gi. Ensure that no single PersistentVolumeClaim can request more than 10Gi.
+Create a namespace, `ps-test`, that limits the total amount of storage that can be requested to 100Gi. Ensure that no more than PersistentVolumeClaims can be requested.
 
 ### Answer
 


### PR DESCRIPTION
According to [docs](https://kubernetes.io/docs/tasks/administer-cluster/limit-storage-consumption/#storagequota-to-limit-pvc-count-and-cumulative-storage-capacity), `persistentvolumeclaims` is for limiting the total number of PVCs.

The change updates the wording in the question and answer to reflect this.

Setting limits on PVCs storage itself is covered [here](https://kubernetes.io/docs/tasks/administer-cluster/limit-storage-consumption/#limitrange-to-limit-requests-for-storage)